### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "sonata-project/notification-orm-pack",
+    "type": "symfony-pack",
+    "description": "A pack for SonataNotificationBundle with ORM support",
+    "keywords": [
+        "notification",
+        "sonata",
+        "orm"
+    ],
+    "homepage": "https://sonata-project.org/bundles/notification",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Thomas Rabaix",
+            "email": "thomas.rabaix@sonata-project.org",
+            "homepage": "https://sonata-project.org"
+        },
+        {
+            "name": "Sonata Community",
+            "homepage": "https://github.com/sonata-project/notification-orm-pack/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.0",
+        "doctrine/doctrine-bundle": "^1.8",
+        "doctrine/orm": "^2.6",
+        "sonata-project/notification-bundle": "^3.5"
+    }
+}


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Added composer.json
```

## Subject

Here `composer.json` contains three dependencies: `doctrine/doctrine-bundle`, `doctrine/orm` and `sonata-project/media-bundle`. I did not include `sonata-project/doctrine-orm-admin-bundle` because admin is disabled by default with [recipe](https://github.com/symfony/recipes-contrib/blob/master/sonata-project/notification-bundle/3.4/config/packages/sonata_notification.yaml).